### PR TITLE
Remove a11y sandbox hole

### DIFF
--- a/com.rafaelmardojai.SharePreview.json
+++ b/com.rafaelmardojai.SharePreview.json
@@ -10,8 +10,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--share=network",
-        "--talk-name=org.a11y.Bus"
+        "--share=network"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",


### PR DESCRIPTION
This is not needed and only exposes unsafe api.